### PR TITLE
MPDF file format

### DIFF
--- a/app/src/androidTest/java/tuhh/nme/mp/data/storage/BloodPressureDataFrameWriterTest.java
+++ b/app/src/androidTest/java/tuhh/nme/mp/data/storage/BloodPressureDataFrameWriterTest.java
@@ -1,0 +1,206 @@
+package tuhh.nme.mp.data.storage;
+
+import android.test.AndroidTestCase;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import tuhh.nme.mp.data.BloodPressureDataFrame;
+import tuhh.nme.mp.data.DataFrame;
+import tuhh.nme.mp.data.HighPrecisionDate;
+import tuhh.nme.mp.data.HighPrecisionTimeSpan;
+
+public class BloodPressureDataFrameWriterTest extends AndroidTestCase
+{
+    // The following functions are covered automatically from other tests:
+    // clear(), isEmpty(), contains(), containsAll(), size()
+
+    /**
+     * Tests the construction.
+     */
+    public void testConstruction()
+    {
+        new BloodPressureDataFrameWriter();
+    }
+
+    /**
+     * Tests the add() function.
+     */
+    public void testAdd()
+    {
+        BloodPressureDataFrameWriter uut = new BloodPressureDataFrameWriter();
+
+        assertEquals(0, uut.size());
+        assertTrue(uut.isEmpty());
+
+        BloodPressureDataFrame frame = new BloodPressureDataFrame(
+            "4,5,12,222",
+            HighPrecisionDate.epoch,
+            HighPrecisionTimeSpan.fromNanoseconds(1));
+
+        uut.add(frame);
+
+        assertEquals(1, uut.size());
+        assertFalse(uut.isEmpty());
+        assertEquals(frame, uut.frames().iterator().next());
+
+        uut.clear();
+
+        assertEquals(0, uut.size());
+        assertTrue(uut.isEmpty());
+    }
+
+    /**
+     * Tests the addAll() function.
+     */
+    public void testAddAll()
+    {
+        BloodPressureDataFrameWriter uut = new BloodPressureDataFrameWriter();
+
+        assertEquals(0, uut.size());
+        assertTrue(uut.isEmpty());
+
+        ArrayList<DataFrame<HighPrecisionDate, Float>> frames = new ArrayList<>();
+        frames.add(new BloodPressureDataFrame("0,55",
+                                              HighPrecisionDate.epoch,
+                                              HighPrecisionTimeSpan.fromMicroseconds(100)));
+        frames.add(new BloodPressureDataFrame("7.5,8.6,9.7",
+                                              HighPrecisionDate.fromMinutes(3),
+                                              HighPrecisionTimeSpan.fromNanoseconds(25)));
+
+        uut.addAll(frames);
+
+        assertEquals(2, uut.size());
+        assertFalse(uut.isEmpty());
+        assertTrue(uut.contains(frames.get(0)));
+        assertTrue(uut.contains(frames.get(1)));
+        assertTrue(uut.containsAll(frames));
+    }
+
+    /**
+     * Tests the remove() function.
+     */
+    public void testRemove()
+    {
+        BloodPressureDataFrameWriter uut = new BloodPressureDataFrameWriter();
+
+        assertEquals(0, uut.size());
+        assertTrue(uut.isEmpty());
+
+        BloodPressureDataFrame frame = new BloodPressureDataFrame(
+            "111",
+            HighPrecisionDate.epoch,
+            HighPrecisionTimeSpan.fromNanoseconds(7));
+
+        uut.add(frame);
+
+        assertEquals(1, uut.size());
+        assertFalse(uut.isEmpty());
+        assertEquals(frame, uut.frames().iterator().next());
+
+        uut.remove(frame);
+
+        assertEquals(0, uut.size());
+        assertTrue(uut.isEmpty());
+    }
+
+    /**
+     * Tests the removeAll() function.
+     */
+    public void testRemoveAll()
+    {
+        BloodPressureDataFrameWriter uut = new BloodPressureDataFrameWriter();
+
+        assertEquals(0, uut.size());
+        assertTrue(uut.isEmpty());
+
+        ArrayList<DataFrame<HighPrecisionDate, Float>> frames = new ArrayList<>();
+        frames.add(new BloodPressureDataFrame("33,32",
+                   HighPrecisionDate.epoch,
+                   HighPrecisionTimeSpan.fromMicroseconds(77)));
+        frames.add(new BloodPressureDataFrame("0.5,6.02,2.02",
+                   HighPrecisionDate.fromMinutes(4),
+                   HighPrecisionTimeSpan.fromNanoseconds(3)));
+
+        uut.addAll(frames);
+
+        assertEquals(2, uut.size());
+        assertFalse(uut.isEmpty());
+        assertTrue(uut.contains(frames.get(0)));
+        assertTrue(uut.contains(frames.get(1)));
+        assertTrue(uut.containsAll(frames));
+
+        uut.removeAll(frames);
+
+        assertEquals(0, uut.size());
+        assertTrue(uut.isEmpty());
+    }
+
+    /**
+     * Tests the complete stream writing and data conversion.
+     */
+    public void testWrite() throws IOException
+    {
+        BloodPressureDataFrame frame = new BloodPressureDataFrame(
+            "1.0,2.4,2.7,0.5",
+            HighPrecisionDate.epoch,
+            HighPrecisionTimeSpan.fromNanoseconds(100));
+
+        BloodPressureDataFrameWriter uut = new BloodPressureDataFrameWriter();
+
+        uut.add(frame);
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+        uut.write(stream);
+
+        byte[] written_data = stream.toByteArray();
+
+        ByteArrayOutputStream compare = new ByteArrayOutputStream();
+        compare.write(new byte[] {0x4D, 0x50, 0x44, 0x46, 0x31});
+
+        compare.write(toByte(HighPrecisionDate.epoch.getTime().toByteArray().length));
+        compare.write(HighPrecisionDate.epoch.getTime().toByteArray());
+        compare.write(toByte(Float.SIZE / Byte.SIZE));
+        compare.write(toByte(1.0f));
+
+        compare.write(
+            toByte(HighPrecisionDate.fromNanoseconds(100).getTime().toByteArray().length));
+        compare.write(HighPrecisionDate.fromNanoseconds(100).getTime().toByteArray());
+        compare.write(toByte(Float.SIZE / Byte.SIZE));
+        compare.write(toByte(2.4f));
+
+        compare.write(
+            toByte(HighPrecisionDate.fromNanoseconds(200).getTime().toByteArray().length));
+        compare.write(HighPrecisionDate.fromNanoseconds(200).getTime().toByteArray());
+        compare.write(toByte(Float.SIZE / Byte.SIZE));
+        compare.write(toByte(2.7f));
+
+        compare.write(
+            toByte(HighPrecisionDate.fromNanoseconds(300).getTime().toByteArray().length));
+        compare.write(HighPrecisionDate.fromNanoseconds(300).getTime().toByteArray());
+        compare.write(toByte(Float.SIZE / Byte.SIZE));
+        compare.write(toByte(0.5f));
+
+        byte[] t = compare.toByteArray();
+        assertEquals(t.length, written_data.length);
+        for (int i = 0; i < written_data.length; i++)
+        {
+            assertEquals(t[i], written_data[i]);
+        }
+    }
+
+    private byte[] toByte(int value)
+    {
+        return ByteBuffer.allocate(Integer.SIZE / Byte.SIZE).putInt(value).array();
+    }
+
+    private byte[] toByte(float value)
+    {
+        return ByteBuffer.allocate(Float.SIZE / Byte.SIZE).putFloat(value).array();
+    }
+
+}

--- a/app/src/androidTest/java/tuhh/nme/mp/data/storage/MPDFFormatExceptionTest.java
+++ b/app/src/androidTest/java/tuhh/nme/mp/data/storage/MPDFFormatExceptionTest.java
@@ -1,0 +1,37 @@
+package tuhh.nme.mp.data.storage;
+
+import android.test.AndroidTestCase;
+
+import tuhh.nme.mp.data.BloodPressureDataFrame;
+import tuhh.nme.mp.data.HighPrecisionDate;
+import tuhh.nme.mp.data.HighPrecisionTimeSpan;
+
+public class MPDFFormatExceptionTest extends AndroidTestCase
+{
+    /**
+     * Tests the construction.
+     */
+    public void testConstruction()
+    {
+        MPDFFormatException uut;
+
+        uut = new MPDFFormatException();
+        assertEquals(null, uut.getReconstructedData());
+
+        uut = new MPDFFormatException("custom message");
+        assertEquals(null, uut.getReconstructedData());
+        assertEquals("custom message", uut.getMessage());
+
+        BloodPressureDataFrame reconstruction =
+            new BloodPressureDataFrame("1,2,3,4,10,53.7",
+                                       HighPrecisionDate.epoch,
+                                       HighPrecisionTimeSpan.fromNanoseconds(1));
+
+        uut = new MPDFFormatException(reconstruction);
+        assertSame(reconstruction, uut.getReconstructedData());
+
+        uut = new MPDFFormatException("this is a message", reconstruction);
+        assertSame(reconstruction, uut.getReconstructedData());
+        assertEquals("this is a message", uut.getMessage());
+    }
+}

--- a/app/src/main/java/tuhh/nme/mp/data/HashMappingList.java
+++ b/app/src/main/java/tuhh/nme/mp/data/HashMappingList.java
@@ -222,7 +222,8 @@ public abstract class HashMappingList<InputType, MappingType>
      * @param object The InputType to map.
      * @return       The mapped MappingType.
      */
-    protected abstract MappingType map(InputType object);
+    protected abstract MappingType map(InputType object)
+        throws IllegalArgumentException, IllegalStateException, NullPointerException;
 
     /**
      * Stores the InputType's together with their converted data of type MappingType.

--- a/app/src/main/java/tuhh/nme/mp/data/storage/BloodPressureDataFrameReader.java
+++ b/app/src/main/java/tuhh/nme/mp/data/storage/BloodPressureDataFrameReader.java
@@ -1,0 +1,22 @@
+package tuhh.nme.mp.data.storage;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Deserializes a BloodPressureDataFrame from stream.
+ */
+public class BloodPressureDataFrameReader extends HighPrecisionDatedDataFrameReader<Float>
+{
+    /**
+     * Converts a chunk of bytes to a Float.
+     *
+     * @param data                 The data to convert.
+     * @return                     The Float.
+     * @throws MPDFFormatException Never thrown.
+     */
+    @Override
+    protected Float deserializeY(byte[] data) throws MPDFFormatException
+    {
+        return ByteBuffer.wrap(data).getFloat();
+    }
+}

--- a/app/src/main/java/tuhh/nme/mp/data/storage/BloodPressureDataFrameWriter.java
+++ b/app/src/main/java/tuhh/nme/mp/data/storage/BloodPressureDataFrameWriter.java
@@ -1,0 +1,29 @@
+package tuhh.nme.mp.data.storage;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Serializes BloodPressureDataFrame's to a stream.
+ */
+public class BloodPressureDataFrameWriter extends HighPrecisionDatedDataFrameWriter<Float>
+{
+    /**
+     * Instantiates a new BloodPressureDataFrameWriter.
+     */
+    public BloodPressureDataFrameWriter()
+    {
+        super();
+    }
+
+    /**
+     * Serializes a Float.
+     *
+     * @param object The Float to serialize.
+     * @return       The serialized data in form of a byte array.
+     */
+    @Override
+    protected byte[] serializeY(Float object)
+    {
+        return ByteBuffer.allocate(Float.SIZE / Byte.SIZE).putFloat(object).array();
+    }
+}

--- a/app/src/main/java/tuhh/nme/mp/data/storage/DataFrameReader.java
+++ b/app/src/main/java/tuhh/nme/mp/data/storage/DataFrameReader.java
@@ -1,0 +1,168 @@
+package tuhh.nme.mp.data.storage;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+
+import tuhh.nme.mp.data.DataFrame;
+import tuhh.nme.mp.data.DataPoint;
+
+/**
+ * The base class for all readers that support the MPDF (MP-DataFrame) format.
+ *
+ * @param <XType> The x-type of the DataFrame to convert to.
+ * @param <YType> The y-type of the DataFrame to convert to.
+ */
+public abstract class DataFrameReader<XType, YType>
+{
+    /**
+     * Reads the data from the given InputStream.
+     *
+     * @param stream               The stream where to read from.
+     * @return                     The back-converted DataFrame.
+     * @throws IOException         Thrown when IO errors occurred while trying to read data.
+     * @throws MPDFFormatException Thrown when the stream data is invalid.
+     */
+    public DataFrame<XType, YType> read(InputStream stream) throws IOException, MPDFFormatException
+    {
+        BufferedInputStream buffered_stream = new BufferedInputStream(stream);
+
+        readHeader(buffered_stream);
+
+        Collection<DataPoint<XType, YType>> entries = readDataEntries(buffered_stream);
+
+        return new DataFrame<>(entries);
+    }
+
+    /**
+     * Converts a chunk of data to an XType.
+     *
+     * @param data                 The data to convert.
+     * @return                     The converted XType.
+     * @throws MPDFFormatException Thrown on invalid input format.
+     */
+    protected abstract XType deserializeX(byte[] data) throws MPDFFormatException;
+
+    /**
+     * Converts a chunk of data to an YType.
+     * @param data                 The data to convert.
+     * @return                     The converted YType.
+     * @throws MPDFFormatException Thrown on invalid input format.
+     */
+    protected abstract YType deserializeY(byte[] data) throws MPDFFormatException;
+
+    /**
+     * Parses and checks the file header.
+     *
+     * @param stream               The stream where to read from.
+     * @throws IOException         Thrown when IO errors occurred while reading from stream.
+     * @throws MPDFFormatException Thrown on invalid file header.
+     */
+    private void readHeader(InputStream stream) throws IOException, MPDFFormatException
+    {
+        byte[] buffer = new byte[FILE_HEADER.length];
+
+        if (stream.read(buffer, 0, buffer.length) < buffer.length)
+        {
+            throwInvalidFileHeaderException();
+        }
+
+        if (!Arrays.equals(buffer, FILE_HEADER))
+        {
+            throwInvalidFileHeaderException();
+        }
+    }
+
+    /**
+     * Parses the DataPoint entries.
+     *
+     * @param stream               The stream where to read from.
+     * @return                     The parsed data.
+     * @throws IOException         Thrown when IO errors occurred while reading from stream.
+     * @throws MPDFFormatException Thrown on invalid data format.
+     */
+    private Collection<DataPoint<XType, YType>> readDataEntries(InputStream stream)
+        throws IOException, MPDFFormatException
+    {
+        byte[] buffer;
+
+        XType x_value;
+        YType y_value;
+        int next_data_length;
+        byte[] data_length_buffer = new byte[4];
+        int read_result;
+
+        LinkedList<DataPoint<XType, YType>> data = new LinkedList<>();
+
+        while((read_result = stream.read(data_length_buffer, 0, data_length_buffer.length)) != -1)
+        {
+            // Extract next DataPoint.
+
+            if (read_result != Integer.SIZE / Byte.SIZE)
+            {
+                throwDataCorruptedException(new DataFrame<>(data));
+            }
+
+            next_data_length = ByteBuffer.wrap(data_length_buffer).getInt();
+
+            buffer = new byte[next_data_length];
+            if (stream.read(buffer, 0, buffer.length) != next_data_length)
+            {
+                throwDataCorruptedException(new DataFrame<>(data));
+            }
+
+            x_value = deserializeX(buffer);
+
+            if (stream.read(data_length_buffer, 0, data_length_buffer.length) !=
+                Integer.SIZE / Byte.SIZE)
+            {
+                throwDataCorruptedException(new DataFrame<>(data));
+            }
+
+            next_data_length = ByteBuffer.wrap(data_length_buffer).getInt();
+
+            buffer = new byte[next_data_length];
+            if (stream.read(buffer, 0, buffer.length) != next_data_length)
+            {
+                throwDataCorruptedException(new DataFrame<>(data));
+            }
+
+            y_value = deserializeY(buffer);
+
+            data.add(new DataPoint<>(x_value, y_value));
+        }
+
+        return data;
+    }
+
+    /**
+     * Throws an MPDFFormatException for invalid file headers.
+     *
+     * @throws MPDFFormatException Thrown every time.
+     */
+    private void throwInvalidFileHeaderException() throws MPDFFormatException
+    {
+        throw new MPDFFormatException("Invalid file header.");
+    }
+
+    /**
+     * Throws an MPDFFormatException for corrupted data.
+     *
+     * @param reconstructed_data   The reconstruction data to initialize the exception with.
+     * @throws MPDFFormatException Thrown every time.
+     */
+    private void throwDataCorruptedException(DataFrame reconstructed_data)
+        throws MPDFFormatException
+    {
+        throw new MPDFFormatException("Data corrupted.", reconstructed_data);
+    }
+
+    /**
+     * The file header.
+     */
+    private final static byte[] FILE_HEADER = {0x4D, 0x50, 0x44, 0x46, 0x31};
+}

--- a/app/src/main/java/tuhh/nme/mp/data/storage/DataFrameWriter.java
+++ b/app/src/main/java/tuhh/nme/mp/data/storage/DataFrameWriter.java
@@ -1,0 +1,231 @@
+package tuhh.nme.mp.data.storage;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+
+import tuhh.nme.mp.data.DataFrame;
+import tuhh.nme.mp.data.DataPoint;
+
+/**
+ * Base class for all DataFrame writer classes.
+ *
+ * @param <XType> The x-type of the DataFrame to save.
+ * @param <YType> The y-type of the DataFrame to save.
+ */
+public abstract class DataFrameWriter<XType, YType>
+{
+    /**
+     * Instantiates a new DataFrameWriter.
+     */
+    public DataFrameWriter()
+    {
+        m_FrameByteMap = new HashMap<>();
+    }
+
+    /**
+     * Adds a DataFrame that should be serialized.
+     *
+     * If the object to add already exists, nothing happens.
+     *
+     * @param object The DataFrame to add.
+     */
+    public void add(DataFrame<XType, YType> object)
+    {
+        if (!m_FrameByteMap.containsKey(object))
+        {
+            m_FrameByteMap.put(object, null);
+        }
+    }
+
+    /**
+     * Adds all DataFrame's in the given collection for serialization.
+     *
+     * Already existent DataFrame's are not added.
+     *
+     * @param collection The collection of DataFrame's to add.
+     */
+    public void addAll(Collection<DataFrame<XType, YType>> collection)
+    {
+        for (DataFrame<XType, YType> elem : collection)
+        {
+            m_FrameByteMap.put(elem, null);
+        }
+    }
+
+    /**
+     * Removes a DataFrame.
+     *
+     * @param object The DataFrame to remove.
+     */
+    public void remove(DataFrame<XType, YType> object)
+    {
+        m_FrameByteMap.remove(object);
+    }
+
+    /**
+     * Removes all DataFrame's that are in the given collection.
+     *
+     * @param collection The collection of DataFrame's to remove.
+     */
+    public void removeAll(Collection<DataFrame<XType, YType>> collection)
+    {
+        for (DataFrame<XType, YType> elem : collection)
+        {
+            m_FrameByteMap.remove(elem);
+        }
+    }
+
+    /**
+     * Removes all DataFrame's.
+     */
+    public void clear()
+    {
+        m_FrameByteMap.clear();
+    }
+
+    /**
+     * Checks whether the given DataFrame is existent.
+     *
+     * @param object The DataFrame to check for.
+     * @return       true if existent, false if not.
+     */
+    public boolean contains(DataFrame<XType, YType> object)
+    {
+        return m_FrameByteMap.containsKey(object);
+    }
+
+    /**
+     * Checks whether all given DataFrame's inside the collection are existent.
+     *
+     * @param collection The collection of DataFrame's to check for.
+     * @return           true if all existent, false if not.
+     */
+    public boolean containsAll(Collection<DataFrame<XType, YType>> collection)
+    {
+        for (DataFrame<XType, YType> elem : collection)
+        {
+            if (!m_FrameByteMap.containsKey(elem))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns whether there are DataFrame's stored or not.
+     *
+     * @return true if empty, false if not.
+     */
+    public boolean isEmpty()
+    {
+        return m_FrameByteMap.isEmpty();
+    }
+
+    /**
+     * Returns the number of stored DataFrame's.
+     *
+     * @return The number of DataFrame's.
+     */
+    public int size()
+    {
+        return m_FrameByteMap.size();
+    }
+
+    /**
+     * Returns the stored DataFrame's.
+     *
+     * @return The collection of DataFrame's.
+     */
+    public Collection<DataFrame<XType, YType>> frames()
+    {
+        return Collections.unmodifiableSet(m_FrameByteMap.keySet());
+    }
+
+    /**
+     * Serializes a DataFrame into a byte array.
+     *
+     * @param object       The DataFrame to serialize.
+     * @return             The serialized DataFrame.
+     * @throws IOException Thrown when errors occurred while writing to the returned array.
+     */
+    private byte[] serializeDataFrame(DataFrame<XType, YType> object) throws IOException
+    {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+
+        for (DataPoint<XType, YType> elem : object)
+        {
+            byte[] serialized_x = serializeX(elem.X);
+            byte[] serialized_y = serializeY(elem.Y);
+
+            buf.write(ByteBuffer.allocate(Integer.SIZE / Byte.SIZE)
+                      .putInt(serialized_x.length).array());
+            buf.write(serialized_x);
+            buf.write(ByteBuffer.allocate(Integer.SIZE / Byte.SIZE)
+                      .putInt(serialized_y.length).array());
+            buf.write(serialized_y);
+        }
+
+        return buf.toByteArray();
+    }
+
+    /**
+     * Serialize and write the stored data.
+     *
+     * @param stream       The stream to write to.
+     * @throws IOException Thrown when errors occurred during stream write.
+     */
+    public void write(OutputStream stream) throws IOException
+    {
+        stream.write(FILE_HEADER);
+
+        for (DataFrame<XType, YType> key : m_FrameByteMap.keySet())
+        {
+            byte[] data;
+            data = m_FrameByteMap.get(key);
+
+            if (data == null)
+            {
+                data = serializeDataFrame(key);
+                m_FrameByteMap.put(key, data);
+            }
+        }
+
+        for (byte[] value : m_FrameByteMap.values())
+        {
+            stream.write(value);
+        }
+    }
+
+    /**
+     * Serializes the x-type of the stored DataFrame's.
+     *
+     * @param object The x-type to serialize.
+     * @return       The serialized data in form of a byte array.
+     */
+    protected abstract byte[] serializeX(XType object);
+
+    /**
+     * Serializes the y-type of the stored DataFrame's.
+     *
+     * @param object The y-type to serialize.
+     * @return       The serialized data in form of a byte array.
+     */
+    protected abstract byte[] serializeY(YType object);
+
+    /**
+     * The underlying hash-map that stores the DataFrame's. Also associates the corresponding
+     * data-chunks to write to the stream for performance boost.
+     */
+    private HashMap<DataFrame<XType, YType>, byte[]> m_FrameByteMap;
+
+    /**
+     * The file header.
+     */
+    private final static byte[] FILE_HEADER = {0x4D, 0x50, 0x44, 0x46, 0x31};
+}

--- a/app/src/main/java/tuhh/nme/mp/data/storage/HighPrecisionDatedDataFrameReader.java
+++ b/app/src/main/java/tuhh/nme/mp/data/storage/HighPrecisionDatedDataFrameReader.java
@@ -1,0 +1,26 @@
+package tuhh.nme.mp.data.storage;
+
+import java.math.BigInteger;
+
+import tuhh.nme.mp.data.HighPrecisionDate;
+
+/**
+ * Base class for all DataFrameReader's with DataFrame's with an x-type of HighPrecisionDate.
+ *
+ * @param <YType> The y-type of the DataFrame.
+ */
+public abstract class HighPrecisionDatedDataFrameReader<YType>
+    extends DataFrameReader<HighPrecisionDate, YType>
+{
+    /**
+     * Converts a byte-chunk to an HighPrecisionDate.
+     * @param data                 The data to convert.
+     * @return                     The HighPrecisionDate represented by the given data chunk.
+     * @throws MPDFFormatException Never thrown.
+     */
+    @Override
+    protected HighPrecisionDate deserializeX(byte[] data) throws MPDFFormatException
+    {
+        return new HighPrecisionDate(new BigInteger(data));
+    }
+}

--- a/app/src/main/java/tuhh/nme/mp/data/storage/HighPrecisionDatedDataFrameWriter.java
+++ b/app/src/main/java/tuhh/nme/mp/data/storage/HighPrecisionDatedDataFrameWriter.java
@@ -1,0 +1,32 @@
+package tuhh.nme.mp.data.storage;
+
+import tuhh.nme.mp.data.HighPrecisionDate;
+
+/**
+ * Base class for all DataFrameWriter's with DataFrame's with an x-type of HighPrecisionDate.
+ *
+ * @param <YType> The y-type of the DataFrame.
+ */
+public abstract class HighPrecisionDatedDataFrameWriter<YType>
+    extends DataFrameWriter<HighPrecisionDate, YType>
+{
+    /**
+     * Instantiates a new HighPrecisionDatedDataFrameWriter.
+     */
+    public HighPrecisionDatedDataFrameWriter()
+    {
+        super();
+    }
+
+    /**
+     * Serializes a HighPrecisionDate.
+     *
+     * @param object The HighPrecisionDate to serialize.
+     * @return       The serialized data in form of a byte array.
+     */
+    @Override
+    protected byte[] serializeX(HighPrecisionDate object)
+    {
+        return object.getTime().toByteArray();
+    }
+}

--- a/app/src/main/java/tuhh/nme/mp/data/storage/MPDFFormatException.java
+++ b/app/src/main/java/tuhh/nme/mp/data/storage/MPDFFormatException.java
@@ -1,0 +1,69 @@
+package tuhh.nme.mp.data.storage;
+
+import java.util.zip.DataFormatException;
+
+import tuhh.nme.mp.data.DataFrame;
+
+/**
+ * Data format exception for the MP-DataFrame format. Supports passing reconstructed data.
+ */
+public class MPDFFormatException extends DataFormatException
+{
+    /**
+     * Instantiates a new MPDFFormatException with default message and no reconstructed data.
+     */
+    public MPDFFormatException()
+    {
+        super();
+        m_Reconstructed = null;
+    }
+
+    /**
+     * Instantiates a new MPDFFormatException with no reconstructed data.
+     *
+     * @param message The custom message of the exception.
+     */
+    public MPDFFormatException(String message)
+    {
+        super(message);
+        m_Reconstructed = null;
+    }
+
+    /**
+     * Instantiates a new MPDFFormatException with default message.
+     *
+     * @param reconstructed The reconstructed data of the corrupted stream.
+     */
+    public MPDFFormatException(DataFrame reconstructed)
+    {
+        super();
+        m_Reconstructed = reconstructed;
+    }
+
+    /**
+     * Instantiates a new MPDFFormatException.
+     *
+     * @param message       The custom message of the exception.
+     * @param reconstructed The reconstructed data of the corrupted stream.
+     */
+    public MPDFFormatException(String message, DataFrame reconstructed)
+    {
+        super(message);
+        m_Reconstructed = reconstructed;
+    }
+
+    /**
+     * Returns the data that could be reconstructed until exception.
+     *
+     * @return The reconstructed DataFrame.
+     */
+    public DataFrame getReconstructedData()
+    {
+        return m_Reconstructed;
+    }
+
+    /**
+     * The reconstructed DataFrame.
+     */
+    private DataFrame m_Reconstructed;
+}


### PR DESCRIPTION
Implements the MPDF file format for storing `DataFrame`s.
Should be improved in #21.

Fixes #6.
